### PR TITLE
fix: increase spacing between dashboard tiles and rows

### DIFF
--- a/src/styles/Dashboard.css
+++ b/src/styles/Dashboard.css
@@ -58,7 +58,7 @@
 
 .welcome-section {
   text-align: center;
-  margin-bottom: 48px;
+  margin-bottom: 60px;
 }
 
 .welcome-section h2 {

--- a/src/styles/Dashboard.css
+++ b/src/styles/Dashboard.css
@@ -100,7 +100,7 @@
   }
   
   .welcome-section {
-    margin-bottom: 32px;
+    margin-bottom: 40px;
   }
   
   .welcome-section h2 {
@@ -113,7 +113,7 @@
   
   .apps-grid {
     grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-    gap: 16px;
+    gap: 24px;
   }
 }
 

--- a/src/styles/Dashboard.css
+++ b/src/styles/Dashboard.css
@@ -77,7 +77,7 @@
 .apps-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 24px;
+  gap: 32px;
   margin-bottom: 40px;
 }
 


### PR DESCRIPTION
This PR addresses the issue with insufficient spacing between dashboard tiles and rows by:

1. Increasing the gap between dashboard tiles from 24px to 32px to provide more visual breathing room between elements
2. Increasing the margin-bottom of the welcome section from 48px to 60px to create more space between the first and second row
3. Updating responsive layout values to maintain consistent spacing on smaller screens:
   - Increased the welcome section margin from 32px to 40px on mobile
   - Increased the tile gap from 16px to 24px on mobile

These changes improve the visual hierarchy and readability of the dashboard by creating more distinct separation between elements, making the interface feel less cluttered and more polished.

The modifications were made only to the Dashboard.css file, keeping the changes focused on the spacing issue without affecting the actual content or functionality of the components.